### PR TITLE
LCOfacility serializes epochofel/perih as mjd

### DIFF
--- a/src/aeonlib/models.py
+++ b/src/aeonlib/models.py
@@ -4,7 +4,7 @@ Models shared between facilities.
 
 from typing import Annotated, Any, Literal
 
-from annotated_types import Ge, Le
+from annotated_types import Le
 from pydantic import BaseModel, ConfigDict
 from pydantic.types import (
     NonNegativeFloat,
@@ -56,7 +56,7 @@ class NonSiderealTarget(BaseModel):
         "MPC_COMET",
     ]
     """The Target scheme to use"""
-    epochofel: Annotated[float, Ge(10_000), Le(100_000)]
+    epochofel: Time
     """The epoch of the orbital elements (MJD)"""
     orbinc: Angle
     """Orbital inclination (angle in degrees)"""
@@ -72,7 +72,7 @@ class NonSiderealTarget(BaseModel):
     """Mean anomaly (angle in degrees)"""
     perihdist: Annotated[float, NonNegativeFloat] | None = None
     """Perihelion distance (AU)"""  # Comet Only
-    epochofperih: Annotated[float, Ge(10_000), Le(100_000)] | None = None
+    epochofperih: Time | None = None
     """Epoch of perihelion (MJD)"""  # Comet Only
     dailymot: float | None = None
     """Daily motion (angle in degrees)"""  # Major Planet Only

--- a/src/aeonlib/ocs/lco/facility.py
+++ b/src/aeonlib/ocs/lco/facility.py
@@ -59,6 +59,8 @@ class LcoFacility:
             return dict_table(proposals, fields)
 
     def serialize_request_group(self, request_group: RequestGroup) -> dict:
+        # The LCO api expects certain time fields to be in MJD format instead of datetime.
+        # The below mapping is accessed in the Time field to output to MJD.
         output_mapping = {"epochofel": "mjd", "epochofperih": "mjd"}
         return request_group.model_dump(
             mode="json", exclude_none=True, context={"output_mapping": output_mapping}

--- a/src/aeonlib/ocs/lco/facility.py
+++ b/src/aeonlib/ocs/lco/facility.py
@@ -34,12 +34,13 @@ class LcoFacility:
 
     def __init__(self, settings=default_settings):
         if not settings.lco_token:
-            logger.warn(
+            logger.info(
                 "AEON_LCO_TOKEN setting is missing, request will be unauthenticated"
             )
+            headers = {}
         else:
-            self.headers = {"Authorization": f"Token {settings.lco_token}"}
-        self.client = httpx.Client(base_url=settings.lco_api_root, headers=self.headers)
+            headers = {"Authorization": f"Token {settings.lco_token}"}
+        self.client = httpx.Client(base_url=settings.lco_api_root, headers=headers)
 
     def __del__(self):
         self.client.close()
@@ -57,10 +58,16 @@ class LcoFacility:
             fields = ["id", "active", "title", "requestgroup_count"]
             return dict_table(proposals, fields)
 
+    def serialize_request_group(self, request_group: RequestGroup) -> dict:
+        output_mapping = {"epochofel": "mjd", "epochofperih": "mjd"}
+        return request_group.model_dump(
+            mode="json", exclude_none=True, context={"output_mapping": output_mapping}
+        )
+
     def validate_request_group(
         self, request_group: RequestGroup
     ) -> tuple[bool, list[Any]]:
-        payload = request_group.model_dump(mode="json", exclude_none=True)
+        payload = self.serialize_request_group(request_group)
         logger.debug("LcoFacility.validate_request_group -> %s", payload)
         response = self.client.post("/requestgroups/validate/", json=payload)
         response = response.json()
@@ -73,7 +80,7 @@ class LcoFacility:
     def submit_request_group(
         self, request_group: RequestGroup
     ) -> SubmittedRequestGroup:
-        payload = request_group.model_dump(mode="json", exclude_none=True)
+        payload = self.serialize_request_group(request_group)
         logger.debug("-> %s", payload)
         response = self.client.post("/requestgroups/", json=payload)
         response.raise_for_status()

--- a/src/aeonlib/types.py
+++ b/src/aeonlib/types.py
@@ -19,7 +19,7 @@ class _AstropyTimeType:
     def __get_pydantic_core_schema__(
         cls,
         _source_type: Type[Any],
-        _handler: GetCoreSchemaHandler,
+        handler: GetCoreSchemaHandler,
     ) -> core_schema.CoreSchema:
         """https://docs.pydantic.dev/latest/concepts/types/#handling-third-party-types"""
 
@@ -33,13 +33,23 @@ class _AstropyTimeType:
             ]
         )
 
-        def serialize_time(time_obj: astropy.time.Time) -> datetime:
+        def serialize_time(
+            model, time_obj: astropy.time.Time, info: core_schema.SerializationInfo
+        ) -> Union[datetime, str, float]:
             """
             Determines how to serialize an astropy.time.Time object when model_dump()
             is called. Potentially we could leave this as is and have astropy times
             in dictionaries, but Pydantic handles datetimes natively so this seems to
             be the path of least resistance.
             """
+            field_name = getattr(info, "field_name", "")
+            context = getattr(info, "context", {})
+            if field_name and context:
+                output_mapping = context.get("output_mapping", {})
+                output_type = output_mapping.get(field_name, "datetime")
+                if output_type == "mjd":
+                    return time_obj.mjd  # type: ignore
+
             return time_obj.datetime  # type: ignore
 
         return core_schema.json_or_python_schema(
@@ -53,7 +63,7 @@ class _AstropyTimeType:
                 ]
             ),
             serialization=core_schema.plain_serializer_function_ser_schema(
-                serialize_time
+                serialize_time, is_field_serializer=True, info_arg=True
             ),
         )
 

--- a/tests/ocs/test_models.py
+++ b/tests/ocs/test_models.py
@@ -1,15 +1,18 @@
 from datetime import datetime, timedelta
 
 import pytest
+from astropy.time import Time
 from pydantic import ValidationError
 
-from aeonlib.models import SiderealTarget, Window
+from aeonlib.conf import Settings
+from aeonlib.models import NonSiderealTarget, SiderealTarget, Window
 from aeonlib.ocs import (
     Constraints,
     Location,
     Request,
     RequestGroup,
 )
+from aeonlib.ocs.lco.facility import LcoFacility
 from aeonlib.ocs.lco.instruments import Lco1M0ScicamSinistro
 
 
@@ -118,3 +121,31 @@ class TestCommonValidationErrors:
             request.acceptability_threshold = 200
         assert exc_info.value.errors()[0]["loc"] == ("acceptability_threshold",)
         assert exc_info.value.errors()[0]["type"] == "less_than_equal"
+
+
+class TestSerialization:
+    def test_time_fields_serialized_as_mjd(self, request_group: RequestGroup):
+        """
+        Test that certain time fields on a RequestGroup are serialized as MJD.
+        This is likely specific to LCO/OCS so only the LCO Facility has this behavior.
+        """
+        facility = LcoFacility(settings=Settings(lco_token="", lco_api_root=""))
+        target = NonSiderealTarget(
+            name="mover",
+            type="ORBITAL_ELEMENTS",
+            scheme="JPL_MINOR_PLANET",
+            epochofel=datetime(2025, 1, 1),  # Time as datetime
+            orbinc=0.0,
+            longascnode=0.0,
+            argofperih=0.0,
+            eccentricity=1.0,
+            meandist=1.0,
+            meananom=0.0,
+            epochofperih=Time(2460676.5, format="jd", scale="tt"),  # Time as JD
+        )
+        request_group.requests[0].configurations[0].target = target
+        result = facility.serialize_request_group(request_group)
+        result_target = result["requests"][0]["configurations"][0]["target"]
+        # Assert that the resulting serialized values are in MJD
+        assert result_target["epochofel"] == 60676.0
+        assert result_target["epochofperih"] == 60676.0


### PR DESCRIPTION
Adds the ability to specify in a facility class which fields should be serialized in a certain way. In this case, the LCO facility should serialize the epochofel epochofperih fields as MJD, while accepting an Astropy Time object. This allows maximum flexibility in entering the date while still sending the format (MJD) that the LCO api expects.